### PR TITLE
Fix overwriting of Rails log level

### DIFF
--- a/lib/srfax.rb
+++ b/lib/srfax.rb
@@ -41,9 +41,13 @@ module SrFax
   }
 
   mattr_accessor :logger
-  # Logger object for use in standalone modeo or with Rails
-  @@logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
-  @@logger.level = Logger::INFO
+  # Logger object for use in standalone mode or with Rails
+  if defined?(Rails)
+    @@logger = Rails.logger
+  else
+    @@logger = Logger.new(STDOUT)
+    @@logger.level = Logger::INFO
+  end
 
   class << self
     # Allow configuring Srfax with a block, these will be the methods default values for passing to 


### PR DESCRIPTION
When the Rails logger is being used, do not overwrite its host-app configured log level.

For example, in development mode, most often the Debug level is used in order to show SQL queries.
