### PR TITLE
Defaults should not take precedence.

### DIFF
--- a/lib/srfax.rb
+++ b/lib/srfax.rb
@@ -302,9 +302,9 @@ module SrFax
     # @param postVariables [String] The list of variables to apply in the POST body when executing the request.
     # @return [Hash] The hash payload value including a proper status. Will never return nil.
     def execute(postVariables)
-      logger.debug postVariables.merge(defaults)
+      logger.debug defaults.merge(postVariables)
       # Redirect where necessary.
-      res = RestClient.post(BASE_URL, postVariables.merge(defaults), { accept: :json })
+      res = RestClient.post(BASE_URL, defaults.merge(postVariables), { accept: :json })
       unless res.code == 200
         return { 'Status' => 'Failed', 'Result' => res.body }.with_indifferent_access
       end

--- a/lib/srfax/version.rb
+++ b/lib/srfax/version.rb
@@ -1,3 +1,3 @@
 module SrFax
-  VERSION = '0.5.3'.freeze
+  VERSION = '0.5.4'.freeze
 end

--- a/lib/srfax/version.rb
+++ b/lib/srfax/version.rb
@@ -1,3 +1,3 @@
 module SrFax
-  VERSION = '0.5.4'.freeze
+  VERSION = '0.5.5'.freeze
 end


### PR DESCRIPTION
The title says it all :)

If a `defaults` is provided, one should be able to override this in the actual method call. As it stands now, that is backward. Fixed by reversing the merge.
