### PR TITLE
Remove outdated `logger` dependency

### DIFF
--- a/srfax.gemspec
+++ b/srfax.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 11.0'
   spec.add_development_dependency 'pry', '~> 0.8'
   spec.add_development_dependency 'yard', '~> 0.8'
-  spec.add_dependency 'logger', '~> 1'
   spec.add_dependency 'activesupport', ['>= 4.2', '< 6']
   spec.add_dependency 'rest-client', '~> 2.0'
 end


### PR DESCRIPTION
`Logger` is part of Ruby and the rubygems version of the `logger` gem just got completely messed up.
So would be nice to just drop this dependency.